### PR TITLE
Implement File Expiration

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install protobuf-compiler
+      run: sudo apt update && sudo apt install -y protobuf-compiler
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+target
+
+*.pb.go
+
+.DS_Store

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// time in secs that a file is valid for
+pub const EXPIRATION_OFFSET: u64 = 3600;
+
+// get the current time in seconds
+pub fn get_current_time() -> u64 {
+    let start = SystemTime::now();
+    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    since_the_epoch.as_secs() as u64
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,5 @@ pub const EXPIRATION_OFFSET: u64 = 3600;
 pub fn get_current_time() -> u64 {
     let start = SystemTime::now();
     let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
-    since_the_epoch.as_secs() as u64
+    since_the_epoch.as_secs()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ impl Market for MarketState {
 
         let mut market_data = self.market_data.lock().await;
 
-        (*market_data.files.entry(file_hash.clone()).or_default()).push(file_request);
+        (*market_data.files.entry(file_hash).or_default()).push(file_request);
 
         Ok(Response::new(()))
     }


### PR DESCRIPTION
When a client calls CheckHolders, files that are expired are removed from the vector and will not be returned. 

Also added some files that were not brought in during init.