### PR TITLE
Only display same producer once

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub const EXPIRATION_OFFSET: u64 = 3600;
 // get the current time in seconds
 pub fn get_current_time() -> u64 {
     let start = SystemTime::now();
-    let since_the_epoch = start.duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
     since_the_epoch.as_secs()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@ impl MarketData {
     fn validate_holders(&self, hash: &String) -> Vec<FileRequest> {
         // make a map of holders already printed
         let mut previous_holders: HashMap<&String, &FileRequest> = HashMap::new();
-        let mut holders: Vec<FileRequest> = Vec::new();
 
         for holder in &self.files[hash] {
             let user = &holder.user;
@@ -50,21 +49,17 @@ impl MarketData {
                 // if the current holder has a more recent ttl, print it and remove the previous holder
                 // if the previous holder has a more recent ttl, skip the current holder
                 let prev_holder = previous_holders.get(&user.id).unwrap();
-                let ttl_holder1 = holder.expiration - get_current_time();
-                let ttl_holder2 = &prev_holder.expiration - get_current_time();
+                let current_holder_ttl = holder.expiration - get_current_time(); // current holder: smaller means older
+                let previous_holder_ttl: u64 = &prev_holder.expiration - get_current_time(); // previous holder: smaller means older
 
-                if ttl_holder1 > ttl_holder2 {
+                if current_holder_ttl > previous_holder_ttl { // if the current holder is younger, remove the previous holder
                     previous_holders.insert(&user.id, &holder);
                 }
                 continue;
             }
             previous_holders.insert(&user.id, &holder);
         }
-        // set holders to the remaining holders
-        for (_, holder) in previous_holders {
-            holders.push(holder.clone());
-        }
-        return holders;
+        return previous_holders.into_iter().map(|(_, holder)| holder.clone()).collect();
     }
 
     fn print_holders_map(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,8 +106,6 @@ impl Market for MarketState {
         // insert the file request into the market data and validate the holders
         market_data.insert_and_validate(&file_hash, &file_request);
 
-        // market_data.files.insert(file_hash, validated_holders); // update the file holders to the validated holders
-
         Ok(Response::new(()))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,20 +52,13 @@ impl MarketData {
             let holder = producers.get(index).unwrap(); // safe to unwrap since index is always within bounds
             let user = &holder.user;
             // check if the user has expired
-            if holder.expiration < current_time {
+            if holder.expiration < current_time || user.id == filerequest.user.id {
                 producers.swap_remove(index);
                 len -= 1; // decrement length since we removed an element
                           // do not increment index since we just swapped the current index with the last element
                 continue;
             } // this if statement must be first, otherwise it may unecessarily add expired holders or compare with expired holders
 
-            // check if the user is the same as the current holder
-            if user.id == filerequest.user.id {
-                producers.swap_remove(index);
-                len -= 1; // decrement length since we removed an element
-                          // do not increment index since we just swapped the current index with the last element
-                continue;
-            }
             index += 1;
         }
         producers.push(filerequest.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,15 +38,16 @@ struct MarketData {
 
 impl MarketData {
     fn insert_and_validate(&mut self, hash: String, filerequest: FileRequest) {
-        // check if self.files[hash] exists
-        if !self.files.contains_key(&hash) {
-            self.files.insert(hash, vec![filerequest]);
-            return;
+        match self.files.get_mut(&hash) {
+            None => {
+                self.files.insert(hash, vec![filerequest]);
+            }
+            Some(producers) => {
+                let current_time = get_current_time();
+                producers.retain(|holder| holder.expiration >= current_time && holder.user.id != filerequest.user.id);
+                producers.push(filerequest);
+            }
         }
-        let current_time = get_current_time();
-        let producers = self.files.get_mut(&hash).unwrap(); // safe to unwrap since we already checked if the key exists
-        producers.retain(|holder| holder.expiration >= current_time && holder.user.id != filerequest.user.id);
-        producers.push(filerequest);
     }
 
     fn print_holders_map(&self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ impl MarketData {
         // check if self.files[hash] exists
         if !self.files.contains_key(&hash) {
             self.files
-                .insert(hash.to_string(), vec![filerequest]);
+                .insert(hash, vec![filerequest]);
+            return;
         }
         let current_time = get_current_time();
         let producers = self.files.get_mut(&hash).unwrap(); // safe to unwrap since we already checked if the key exists

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,14 +52,18 @@ impl MarketData {
                 let current_holder_ttl = holder.expiration - get_current_time(); // current holder: smaller means older
                 let previous_holder_ttl: u64 = &prev_holder.expiration - get_current_time(); // previous holder: smaller means older
 
-                if current_holder_ttl > previous_holder_ttl { // if the current holder is younger, remove the previous holder
+                if current_holder_ttl > previous_holder_ttl {
+                    // if the current holder is younger, remove the previous holder
                     previous_holders.insert(&user.id, &holder);
                 }
                 continue;
             }
             previous_holders.insert(&user.id, &holder);
         }
-        return previous_holders.into_iter().map(|(_, holder)| holder.clone()).collect();
+        return previous_holders
+            .into_iter()
+            .map(|(_, holder)| holder.clone())
+            .collect();
     }
 
     fn print_holders_map(&mut self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,6 @@ impl MarketData {
                           // do not increment index since we just swapped the current index with the last element
                 continue;
             } // this if statement must be first, otherwise it may unecessarily add expired holders or compare with expired holders
-              // if both duplicated holders are expired - we don't need either.
 
             // check if the user is the same as the current holder
             if user.id == filerequest.user.id {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use market::{CheckHoldersRequest, HoldersResponse, RegisterFileRequest, User};
@@ -40,8 +40,16 @@ impl MarketData {
     fn print_holders_map(&self) {
         for (hash, holders) in &self.files {
             println!("File Hash: {hash}");
+            // make a map of holders already printed
+            let mut holders_already_printed = HashSet::new();
             for holder in holders {
                 let user = &holder.user;
+                // check if multiple holders have the same id
+                if holders_already_printed.contains(&user.id) {
+                    // add more logic to remove duplicates
+                    continue;
+                }
+                holders_already_printed.insert(&user.id);
                 println!("Username: {}, Price: {}", user.name, user.price);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,10 +37,11 @@ struct MarketData {
 }
 
 impl MarketData {
-    fn insert_and_validate(&mut self, hash: String, filerequest: FileRequest) {
-        match self.files.get_mut(&hash) {
+    fn insert_and_validate(&mut self, filerequest: FileRequest) {
+        let hash = &filerequest.file_hash;
+        match self.files.get_mut(hash) {
             None => {
-                self.files.insert(hash, vec![filerequest]);
+                self.files.insert(hash.clone(), vec![filerequest]);
             }
             Some(producers) => {
                 let current_time = get_current_time();
@@ -77,13 +78,9 @@ impl Market for MarketState {
         let register_file_data = request.into_inner();
         let file_request = FileRequest::from(register_file_data)
             .map_err(|()| Status::invalid_argument("User not present"))?;
-        let file_hash = file_request.file_hash.clone();
-
         let mut market_data = self.market_data.lock().await;
-
         // insert the file request into the market data and validate the holders
-        market_data.insert_and_validate(file_hash, file_request);
-
+        market_data.insert_and_validate(file_request);
         Ok(Response::new(()))
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,14 +37,14 @@ struct MarketData {
 }
 
 impl MarketData {
-    fn insert_and_validate(&mut self, hash: &str, filerequest: &FileRequest) {
+    fn insert_and_validate(&mut self, hash: String, filerequest: FileRequest) {
         // check if self.files[hash] exists
-        if !self.files.contains_key(hash) {
+        if !self.files.contains_key(&hash) {
             self.files
-                .insert(hash.to_string(), vec![filerequest.clone()]);
+                .insert(hash.to_string(), vec![filerequest]);
         }
         let current_time = get_current_time();
-        let producers = self.files.get_mut(hash).unwrap(); // safe to unwrap since we already checked if the key exists
+        let producers = self.files.get_mut(&hash).unwrap(); // safe to unwrap since we already checked if the key exists
         let mut index = 0;
         let mut len = producers.len();
 
@@ -61,7 +61,7 @@ impl MarketData {
 
             index += 1;
         }
-        producers.push(filerequest.clone());
+        producers.push(filerequest);
     }
 
     fn print_holders_map(&self) {
@@ -96,7 +96,7 @@ impl Market for MarketState {
         let mut market_data = self.market_data.lock().await;
 
         // insert the file request into the market data and validate the holders
-        market_data.insert_and_validate(&file_hash, &file_request);
+        market_data.insert_and_validate(file_hash, file_request);
 
         Ok(Response::new(()))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,28 +40,12 @@ impl MarketData {
     fn insert_and_validate(&mut self, hash: String, filerequest: FileRequest) {
         // check if self.files[hash] exists
         if !self.files.contains_key(&hash) {
-            self.files
-                .insert(hash, vec![filerequest]);
+            self.files.insert(hash, vec![filerequest]);
             return;
         }
         let current_time = get_current_time();
         let producers = self.files.get_mut(&hash).unwrap(); // safe to unwrap since we already checked if the key exists
-        let mut index = 0;
-        let mut len = producers.len();
-
-        while index < len {
-            let holder = producers.get(index).unwrap(); // safe to unwrap since index is always within bounds
-            let user = &holder.user;
-            // check if the user has expired
-            if holder.expiration < current_time || user.id == filerequest.user.id {
-                producers.swap_remove(index);
-                len -= 1; // decrement length since we removed an element
-                          // do not increment index since we just swapped the current index with the last element
-                continue;
-            } // this if statement must be first, otherwise it may unecessarily add expired holders or compare with expired holders
-
-            index += 1;
-        }
+        producers.retain(|holder| holder.expiration >= current_time && holder.user.id != filerequest.user.id);
         producers.push(filerequest);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,9 @@ impl MarketData {
             }
             Some(producers) => {
                 let current_time = get_current_time();
-                producers.retain(|holder| holder.expiration >= current_time && holder.user.id != filerequest.user.id);
+                producers.retain(|holder| {
+                    holder.expiration >= current_time && holder.user.id != filerequest.user.id
+                });
                 producers.push(filerequest);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,13 +105,6 @@ impl Market for MarketState {
 
         let mut market_data = self.market_data.lock().await;
 
-        // check if the file hash exists
-        // if market_data.files.contains_key(&file_hash) {
-        //     // if the file hash exists, iterate through the holders and remove user if user is the same
-        //     let holders = market_data.files.get_mut(&file_hash).unwrap();
-        //     holders.retain(|holder| holder.user.id != file_request.user.id);
-        // }
-
         (*market_data.files.entry(file_hash.clone()).or_default()).push(file_request);
 
         // get the validated holders - remove expired and duplicated holders


### PR DESCRIPTION
Closes #4: When a producer with a specified id registers a file multiple times, they will appear multiple times under the holders hashmap.

This is unintended behavior because if a producer loses connection and would like to re-register with the market, or they re-registered earlier, or the price for that file has changed, then the previous producer with that id should be invalidated and the new one should be the only one shown

This PR includes a solution in the `insert_and_validate` function, which will insert a new producer to the vec of file holders such that no other holder has the same id or is expired. Order is maintained, so that in the future binary search can be implemented to remove expired holders. 