### PR TITLE
Bug Fix: Change "127.0.0.1" to "0.0.0.0" for gRPC server

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,7 @@ impl Server {
     }
 
     async fn server(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let addr = "127.0.0.1:50051".parse()?;
+        let addr = "0.0.0.0:50051".parse()?;
 
         let market_state = MarketState {
             market_data: self.market_data.clone(),


### PR DESCRIPTION
It seems that hard coding the IP for the gRPC server to "127.0.0.1" can cause problems in weird network environments - for example I was trying to run the market server in a Docker container and it was not accessible. Changing this to 0.0.0.0 should work regardless of the network environment.